### PR TITLE
fix: last name shows as undefined if user has no last name

### DIFF
--- a/src/modules/BookingSteps.js
+++ b/src/modules/BookingSteps.js
@@ -113,7 +113,7 @@ function completeBooking(bot, query, bookerList) {
 
 	if (booking.chatType == query.chat.type) {
 		let summary = query.text;
-		let fullname = query.from.first_name + ' ' + query.from.last_name;
+		let fullname = `${query.from.first_name}${query.from.last_name ? ` ${query.from.last_name}` : ''}`;
 
 		insertBookingIntoCalendar(bot, booking.id, booking.msgid, summary, booking.room,
 			new Date().setDateWithSimpleFormat(booking.date), booking.time, booking.dur, booking.name, fullname);


### PR DESCRIPTION
# Problem

<img width="293" alt="Screenshot 2024-02-20 at 14 53 45" src="https://github.com/GovTechSG/butler-bot/assets/932949/c27b2d69-797b-49e4-a2fb-e1c9db91918e">

The last name becomes `undefined` is no last name exists on Telegram user profile.

# Proposed Solution

Only concatenate last name if it exists. Telegram only mandates first names.